### PR TITLE
Add xdg-open shim for codespace environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The shim replaces the standard `xdg-open` and routes each request based on what 
 | Type | Viewer |
 |---|---|
 | Images (jpg, png, gif, …) | `chafa` |
-| PDFs | `pdftotext` + `less` |
+| PDFs | `pdftotext` + `less`, or `pdfinfo` |
 | Markdown | `glow`, then `bat`, then `$EDITOR` |
 | Everything else | `$EDITOR`, then `vi` |
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,35 @@ You can create or update this setting directly from the command line by supplyin
 | [Browser Opening](docs/browser-opening.md) | Opens URLs from your codespace in your local browser |
 | [Notifications](docs/notifications.md) | Desktop notifications when long-running commands finish |
 | [Port Forwarding](docs/port-forwarding.md) | Automatic bi-directional port forwarding (including local AI services) |
+| [xdg-open shim](#xdg-open-shim) | Intelligent file and URL opener for SSH / tmux environments |
+
+### xdg-open shim
+
+`gh ado-codespaces` automatically installs an `xdg-open` shim into the codespace at `/usr/local/bin/xdg-open`. No configuration is needed.
+
+The shim replaces the standard `xdg-open` and routes each request based on what is being opened and how you are connected.
+
+**URLs** (`http://`, `https://`, `mailto:`, `ftp://`) are forwarded through the following chain, stopping at the first success:
+
+1. The gh-ado browser socket (the same service that powers [browser opening](docs/browser-opening.md))
+2. `$BROWSER`, if set
+3. `code --open-url` (VS Code remote)
+4. The real `/usr/bin/xdg-open`
+
+**Files** are opened with a viewer chosen by file type:
+
+| Type | Viewer |
+|---|---|
+| Images (jpg, png, gif, …) | `chafa` |
+| PDFs | `pdftotext` + `less` |
+| Markdown | `glow`, then `bat`, then `$EDITOR` |
+| Everything else | `$EDITOR`, then `vi` |
+
+The viewer is launched in whichever environment is active:
+
+- **Inside tmux** — opens in a new vertical split pane. Editors (vim, nvim, …) open directly; non-interactive viewers (chafa, bat, …) pause with a "press enter" prompt so you can read the output.
+- **SSH without tmux** — runs the viewer inline in the current terminal (blocking).
+- **Not in SSH** — delegates to the real `/usr/bin/xdg-open` or VS Code, falling back to the inline viewer.
 
 ## Testing
 

--- a/bash.go
+++ b/bash.go
@@ -1,6 +1,12 @@
 package main
 
-import "strings"
+import (
+	_ "embed"
+	"strings"
+)
+
+//go:embed xdg-open.sh
+var xdgOpenScript string
 
 func wrapBashLoginCommand(command string) []string {
 	return []string{"bash", "-lc", quoteForShell(command)}

--- a/main.go
+++ b/main.go
@@ -245,8 +245,13 @@ func prepareCodespaceScripts(ctx context.Context, codespaceName string, hasBrows
 			fmt.Sprintf("printf %%s %s | base64 -d > ~/notification-sender.sh", notifB64))
 	}
 
+	// xdg-open wrapper (always uploaded; handles its own fallbacks)
+	xdgB64 := base64.StdEncoding.EncodeToString([]byte(xdgOpenScript))
+	cmdParts = append(cmdParts,
+		fmt.Sprintf("printf %%s %s | base64 -d > ~/xdg-open.sh", xdgB64))
+
 	// Make all scripts executable
-	chmodFiles := "~/ado-auth-helper ~/azure-auth-helper ~/port-monitor.sh"
+	chmodFiles := "~/ado-auth-helper ~/azure-auth-helper ~/port-monitor.sh ~/xdg-open.sh"
 	if hasBrowserService {
 		chmodFiles += " ~/browser-opener.sh"
 	}
@@ -260,6 +265,8 @@ func prepareCodespaceScripts(ctx context.Context, codespaceName string, hasBrows
 		"(test -L /usr/local/bin/ado-auth-helper || sudo ln -sf ~/ado-auth-helper /usr/local/bin/ado-auth-helper)")
 	cmdParts = append(cmdParts,
 		"(test -L /usr/local/bin/azure-auth-helper || sudo ln -sf ~/azure-auth-helper /usr/local/bin/azure-auth-helper)")
+	cmdParts = append(cmdParts,
+		"(test -L /usr/local/bin/xdg-open || sudo ln -sf ~/xdg-open.sh /usr/local/bin/xdg-open)")
 
 	// Clean up stale sockets
 	if cleanupCmd := buildStaleSocketCleanupCommand(hasBrowserService, hasNotificationService); cleanupCmd != "" {
@@ -276,6 +283,7 @@ func prepareCodespaceScripts(ctx context.Context, codespaceName string, hasBrows
 
 	// Print success messages
 	fmt.Fprintln(os.Stderr, "ADO and Azure auth helpers uploaded to the codespace and made executable")
+	fmt.Fprintln(os.Stderr, "xdg-open installed at /usr/local/bin/xdg-open")
 	if hasBrowserService {
 		fmt.Fprintf(os.Stderr, "\nBrowser opener available! To enable browser forwarding, add to your shell config:\n")
 		fmt.Fprintf(os.Stderr, "  export BROWSER=\"$HOME/browser-opener.sh\"\n\n")

--- a/xdg-open.sh
+++ b/xdg-open.sh
@@ -7,7 +7,8 @@
 #             in a tmux pane (if available), via VS Code, or inline over SSH.
 #
 # Anti-recursion: this script never calls "xdg-open" from PATH.
-# When delegating to the real binary it uses /usr/bin/xdg-open (hardcoded).
+# When delegating to the real binary it uses a hardcoded path (/usr/bin/xdg-open
+# or /bin/xdg-open) to avoid calling ourselves.
 
 set -euo pipefail
 
@@ -47,7 +48,7 @@ open_url() {
 
     # 2. If $BROWSER is set, delegate to it.
     if [[ -n "${BROWSER:-}" ]]; then
-        exec "$BROWSER" "$url"
+        "$BROWSER" "$url" && return 0
     fi
 
     # 3. Try VS Code remote's `code --open-url`.
@@ -55,9 +56,12 @@ open_url() {
         code --open-url "$url" &>/dev/null && return 0
     fi
 
-    # 4. Try the real xdg-open (hardcoded path to avoid calling ourselves).
+    # 4. Try the real xdg-open (hardcoded paths to avoid calling ourselves;
+    #    /usr/bin is standard on Ubuntu-based codespaces, /bin is a fallback).
     if [[ -x /usr/bin/xdg-open ]]; then
         /usr/bin/xdg-open "$url" &>/dev/null && return 0
+    elif [[ -x /bin/xdg-open ]]; then
+        /bin/xdg-open "$url" &>/dev/null && return 0
     fi
 
     # 5. Silent no-op — headless environment, nothing else we can do.
@@ -68,7 +72,8 @@ open_url() {
 # File handling
 # ---------------------------------------------------------------------------
 
-# detect_viewer: emit the shell command (as a string) to view the given file.
+# detect_viewer: sets the global VIEWER_CMD array to the command + args
+# needed to view the given file. Uses an array to avoid eval/injection risks.
 detect_viewer() {
     local file="$1"
     local ext="${file##*.}"
@@ -76,30 +81,26 @@ detect_viewer() {
 
     case "$ext" in
         jpg|jpeg|png|gif|bmp|webp|tiff|svg)
-            # Terminal image viewer.
             if command -v chafa &>/dev/null; then
-                echo "chafa $(printf '%q' "$file")"
+                VIEWER_CMD=(chafa "$file")
                 return
             fi
             ;;
         pdf)
             if command -v pdftotext &>/dev/null; then
-                echo "pdftotext $(printf '%q' "$file") - | less"
+                VIEWER_CMD=(bash -c "pdftotext $(printf '%q' "$file") - | less")
                 return
             elif command -v pdfinfo &>/dev/null; then
-                echo "pdfinfo $(printf '%q' "$file")"
+                VIEWER_CMD=(pdfinfo "$file")
                 return
             fi
             ;;
         md|markdown)
             if command -v glow &>/dev/null; then
-                echo "glow $(printf '%q' "$file")"
+                VIEWER_CMD=(glow "$file")
                 return
             elif command -v bat &>/dev/null; then
-                echo "bat $(printf '%q' "$file")"
-                return
-            elif [[ -n "${EDITOR:-}" ]]; then
-                echo "${EDITOR} $(printf '%q' "$file")"
+                VIEWER_CMD=(bat "$file")
                 return
             fi
             ;;
@@ -107,22 +108,36 @@ detect_viewer() {
 
     # Everything else: use $EDITOR or fall back to vi.
     if [[ -n "${EDITOR:-}" ]]; then
-        echo "${EDITOR} $(printf '%q' "$file")"
+        VIEWER_CMD=("$EDITOR" "$file")
     else
-        echo "vi $(printf '%q' "$file")"
+        VIEWER_CMD=(vi "$file")
     fi
 }
 
-# is_interactive_editor: returns 0 if the viewer command is an editor
-# (interactive — no need for a "press enter" prompt after it exits).
+# is_interactive_editor: returns 0 if VIEWER_CMD is a known interactive editor.
+# Checks the executable name only (first element of the array).
 is_interactive_editor() {
-    local cmd="$1"
-    case "$cmd" in
-        vi\ *|vim\ *|nvim\ *|nano\ *|emacs\ *|micro\ *|*"$EDITOR"*)
+    local exe
+    exe="$(basename "${VIEWER_CMD[0]}")"
+    case "$exe" in
+        vi|vim|nvim|nano|emacs|emacsclient|micro|hx|helix|kak|kakoune)
             return 0
             ;;
     esac
     return 1
+}
+
+# real_xdg_open: call the system xdg-open using a hardcoded path so we never
+# recurse into ourselves. /usr/bin is standard on Ubuntu-based codespaces;
+# /bin is an additional fallback for other distributions.
+real_xdg_open() {
+    if [[ -x /usr/bin/xdg-open ]]; then
+        /usr/bin/xdg-open "$@"
+    elif [[ -x /bin/xdg-open ]]; then
+        /bin/xdg-open "$@"
+    else
+        return 1
+    fi
 }
 
 # open_file: open a file using the best available strategy.
@@ -134,27 +149,28 @@ open_file() {
         exit 2
     fi
 
-    local viewer_cmd
-    viewer_cmd="$(detect_viewer "$file")"
+    # VIEWER_CMD is set as a global array by detect_viewer.
+    VIEWER_CMD=()
+    detect_viewer "$file"
 
     if [[ -n "${TMUX:-}" ]]; then
         # Inside a tmux session → open in a vertical split pane.
-        if is_interactive_editor "$viewer_cmd"; then
-            # Editors are fully interactive; just run them directly.
-            tmux split-window -h "$viewer_cmd"
+        if is_interactive_editor; then
+            # Editors are fully interactive; run them directly.
+            tmux split-window -h "${VIEWER_CMD[@]}"
         else
             # Non-interactive viewers (chafa, bat, less…): keep the pane open
             # until the user presses Enter so they can read the output.
-            tmux split-window -h "${viewer_cmd}; read -r -p 'Press enter to close...'"
+            # We pass the command as a quoted string to bash -c so that tmux
+            # receives a single string argument (no eval of user-controlled data).
+            local quoted_cmd
+            printf -v quoted_cmd '%q ' "${VIEWER_CMD[@]}"
+            tmux split-window -h "bash -c ${quoted_cmd@Q}; read -r -p 'Press enter to close...'"
         fi
 
     elif [[ -z "${SSH_TTY:-}" && -z "${SSH_CONNECTION:-}" ]]; then
         # Not in an SSH session — try graphical/desktop openers first.
-
-        # Try real xdg-open (hardcoded path).
-        if [[ -x /usr/bin/xdg-open ]]; then
-            /usr/bin/xdg-open "$file" &>/dev/null && return 0
-        fi
+        real_xdg_open "$file" &>/dev/null && return 0
 
         # Try VS Code.
         if command -v code &>/dev/null; then
@@ -162,11 +178,11 @@ open_file() {
         fi
 
         # Fall through to inline viewer.
-        eval "$viewer_cmd"
+        "${VIEWER_CMD[@]}"
 
     else
         # SSH session without tmux → run viewer inline (blocking).
-        eval "$viewer_cmd"
+        "${VIEWER_CMD[@]}"
     fi
 }
 
@@ -175,8 +191,14 @@ open_file() {
 # ---------------------------------------------------------------------------
 
 # Detect whether the target looks like a URL (http, https, mailto, ftp).
+# file:// URLs are routed to open_file after stripping the scheme prefix.
 if [[ "$TARGET" =~ ^(https?|mailto|ftp):// ]]; then
     open_url "$TARGET"
+elif [[ "$TARGET" =~ ^file:// ]]; then
+    # Strip the file:// prefix (and optional localhost authority) to get the path.
+    file_path="${TARGET#file://}"
+    file_path="${file_path#localhost}"
+    open_file "$file_path"
 else
     open_file "$TARGET"
 fi

--- a/xdg-open.sh
+++ b/xdg-open.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# xdg-open shim for GitHub Codespaces (SSH environment)
+#
+# Replaces the real xdg-open and intelligently routes open requests:
+#   - URLs  → forwarded via gh-ado browser socket, $BROWSER, VS Code, or silent no-op
+#   - Files → opened with an appropriate viewer (chafa, pdftotext, glow, bat, $EDITOR…)
+#             in a tmux pane (if available), via VS Code, or inline over SSH.
+#
+# Anti-recursion: this script never calls "xdg-open" from PATH.
+# When delegating to the real binary it uses /usr/bin/xdg-open (hardcoded).
+
+set -euo pipefail
+
+TARGET="${1:-}"
+
+if [[ -z "$TARGET" ]]; then
+    echo "Usage: $(basename "$0") <url-or-file>" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# URL handling
+# ---------------------------------------------------------------------------
+
+# open_url: try multiple strategies to open a URL, falling back gracefully.
+open_url() {
+    local url="$1"
+
+    # 1. Try the gh-ado browser socket (gh-ado-codespaces port-forwarding service).
+    #    Mirror the exact discovery pattern used by browser-opener.sh.
+    if command -v curl &>/dev/null && command -v jq &>/dev/null; then
+        local encoded_url
+        encoded_url="$(printf %s "$url" | jq -sRr @uri)"
+
+        # Find all sockets, sort newest-first so we prefer the active one.
+        local sock
+        while IFS= read -r sock; do
+            [[ -z "$sock" ]] && continue
+            if curl -s --max-time 2 --unix-socket "$sock" \
+                    -X POST "http://localhost/open?url=${encoded_url}" \
+                    >/dev/null 2>&1; then
+                return 0
+            fi
+        done < <(find /tmp -maxdepth 1 -name "gh-ado-browser-*.sock" -type s \
+                     -exec ls -t {} + 2>/dev/null)
+    fi
+
+    # 2. If $BROWSER is set, delegate to it.
+    if [[ -n "${BROWSER:-}" ]]; then
+        exec "$BROWSER" "$url"
+    fi
+
+    # 3. Try VS Code remote's `code --open-url`.
+    if command -v code &>/dev/null; then
+        code --open-url "$url" &>/dev/null && return 0
+    fi
+
+    # 4. Try the real xdg-open (hardcoded path to avoid calling ourselves).
+    if [[ -x /usr/bin/xdg-open ]]; then
+        /usr/bin/xdg-open "$url" &>/dev/null && return 0
+    fi
+
+    # 5. Silent no-op — headless environment, nothing else we can do.
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# File handling
+# ---------------------------------------------------------------------------
+
+# detect_viewer: emit the shell command (as a string) to view the given file.
+detect_viewer() {
+    local file="$1"
+    local ext="${file##*.}"
+    ext="${ext,,}"  # lowercase
+
+    case "$ext" in
+        jpg|jpeg|png|gif|bmp|webp|tiff|svg)
+            # Terminal image viewer.
+            if command -v chafa &>/dev/null; then
+                echo "chafa $(printf '%q' "$file")"
+                return
+            fi
+            ;;
+        pdf)
+            if command -v pdftotext &>/dev/null; then
+                echo "pdftotext $(printf '%q' "$file") - | less"
+                return
+            elif command -v pdfinfo &>/dev/null; then
+                echo "pdfinfo $(printf '%q' "$file")"
+                return
+            fi
+            ;;
+        md|markdown)
+            if command -v glow &>/dev/null; then
+                echo "glow $(printf '%q' "$file")"
+                return
+            elif command -v bat &>/dev/null; then
+                echo "bat $(printf '%q' "$file")"
+                return
+            elif [[ -n "${EDITOR:-}" ]]; then
+                echo "${EDITOR} $(printf '%q' "$file")"
+                return
+            fi
+            ;;
+    esac
+
+    # Everything else: use $EDITOR or fall back to vi.
+    if [[ -n "${EDITOR:-}" ]]; then
+        echo "${EDITOR} $(printf '%q' "$file")"
+    else
+        echo "vi $(printf '%q' "$file")"
+    fi
+}
+
+# is_interactive_editor: returns 0 if the viewer command is an editor
+# (interactive — no need for a "press enter" prompt after it exits).
+is_interactive_editor() {
+    local cmd="$1"
+    case "$cmd" in
+        vi\ *|vim\ *|nvim\ *|nano\ *|emacs\ *|micro\ *|*"$EDITOR"*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+# open_file: open a file using the best available strategy.
+open_file() {
+    local file="$1"
+
+    if [[ ! -e "$file" ]]; then
+        echo "$(basename "$0"): '$file': No such file or directory" >&2
+        exit 2
+    fi
+
+    local viewer_cmd
+    viewer_cmd="$(detect_viewer "$file")"
+
+    if [[ -n "${TMUX:-}" ]]; then
+        # Inside a tmux session → open in a vertical split pane.
+        if is_interactive_editor "$viewer_cmd"; then
+            # Editors are fully interactive; just run them directly.
+            tmux split-window -h "$viewer_cmd"
+        else
+            # Non-interactive viewers (chafa, bat, less…): keep the pane open
+            # until the user presses Enter so they can read the output.
+            tmux split-window -h "${viewer_cmd}; read -r -p 'Press enter to close...'"
+        fi
+
+    elif [[ -z "${SSH_TTY:-}" && -z "${SSH_CONNECTION:-}" ]]; then
+        # Not in an SSH session — try graphical/desktop openers first.
+
+        # Try real xdg-open (hardcoded path).
+        if [[ -x /usr/bin/xdg-open ]]; then
+            /usr/bin/xdg-open "$file" &>/dev/null && return 0
+        fi
+
+        # Try VS Code.
+        if command -v code &>/dev/null; then
+            code "$file" &>/dev/null && return 0
+        fi
+
+        # Fall through to inline viewer.
+        eval "$viewer_cmd"
+
+    else
+        # SSH session without tmux → run viewer inline (blocking).
+        eval "$viewer_cmd"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main dispatch
+# ---------------------------------------------------------------------------
+
+# Detect whether the target looks like a URL (http, https, mailto, ftp).
+if [[ "$TARGET" =~ ^(https?|mailto|ftp):// ]]; then
+    open_url "$TARGET"
+else
+    open_file "$TARGET"
+fi


### PR DESCRIPTION
## Summary

Adds a smart `xdg-open` shim (`xdg-open.sh`) that replaces the system `xdg-open` inside GitHub Codespaces. It is automatically uploaded and symlinked at `/usr/local/bin/xdg-open` on every session start — no user configuration required.

## URL routing (in priority order)
1. **gh-ado browser socket** — forwards to the host browser via the existing port-forwarding tunnel (mirrors `browser-opener.sh`)
2. **`$BROWSER`** env var — delegates to whatever the user has set
3. **`code --open-url`** — VS Code remote
4. **`/usr/bin/xdg-open`** — hardcoded path to avoid calling ourselves recursively
5. Silent no-op (headless environment)

## File opening — environment-aware
| Context | Behaviour |
|---|---|
| **In tmux** | Opens in a new vertical split pane (`tmux split-window -h`) |
| **Not in SSH** | Tries `/usr/bin/xdg-open` → `code` → inline viewer |
| **SSH, no tmux** | Runs viewer inline (blocking) |

## File-type viewers (graceful fallback at each step)
| Type | Viewer |
|---|---|
| Images (jpg/png/gif/…) | `chafa` |
| PDFs | `pdftotext` + `less`, or `pdfinfo` |
| Markdown (.md) | `glow` → `bat` → `$EDITOR` |
| Everything else | `$EDITOR` → `vi` |

## Changes
- **`xdg-open.sh`** — new 183-line bash shim
- **`bash.go`** — `//go:embed xdg-open.sh` + `var xdgOpenScript string`
- **`main.go`** — uploads, chmods, and symlinks the shim in `prepareCodespaceScripts`
- **`README.md`** — documents the new shim