### PR TITLE
Fix Windows codespace script preparation

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -339,6 +340,7 @@ func runCodespaceBashScript(ctx context.Context, codespaceName, script string) (
 
 	cmd := exec.CommandContext(ctx, ghExe, buildCodespaceBashStdinArgs(codespaceName)...)
 	cmd.Stdin = strings.NewReader(script)
+	cmd.Stdout = io.Discard
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/main.go
+++ b/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"sort"
@@ -242,10 +244,27 @@ func sanitizeForFilename(name string) string {
 	return result
 }
 
-// prepareCodespaceScripts writes all helper scripts to the codespace in a
-// single SSH call using base64-encoded content, then makes them executable
-// and creates symlinks. This avoids multiple expensive relay connections.
+// prepareCodespaceScripts writes all helper scripts to the codespace in a single SSH session.
 func prepareCodespaceScripts(ctx context.Context, codespaceName string, hasBrowserService, hasNotificationService bool) error {
+	script := buildCodespacePreparationScript(hasBrowserService, hasNotificationService)
+	stderr, err := runCodespaceBashScript(ctx, codespaceName, script)
+	if err != nil {
+		return fmt.Errorf("error preparing scripts: %w\nStderr: %s", err, stderr)
+	}
+
+	// Print success messages
+	fmt.Fprintln(os.Stderr, "ADO and Azure auth helpers uploaded to the codespace and made executable")
+	fmt.Fprintln(os.Stderr, "xdg-open installed at /usr/local/bin/xdg-open")
+	if hasBrowserService {
+		fmt.Fprintf(os.Stderr, "\nBrowser opener available! To enable browser forwarding, add to your shell config:\n")
+		fmt.Fprintf(os.Stderr, "  export BROWSER=\"$HOME/browser-opener.sh\"\n\n")
+	}
+
+	return nil
+}
+
+// buildCodespacePreparationScript returns the remote setup script sent over stdin.
+func buildCodespacePreparationScript(hasBrowserService, hasNotificationService bool) string {
 	var cmdParts []string
 
 	// Base64-encode and write auth helper to two destinations
@@ -300,23 +319,35 @@ func prepareCodespaceScripts(ctx context.Context, codespaceName string, hasBrows
 		cmdParts = append(cmdParts, cleanupCmd)
 	}
 
-	fullCmd := strings.Join(cmdParts, " && ")
+	return "set -e\n" + strings.Join(cmdParts, "\n") + "\n"
+}
 
-	args := append([]string{"codespace", "ssh", "--codespace", codespaceName, "--"}, wrapBashLoginCommand(fullCmd)...)
-	_, stderr, err := gh.Exec(args...)
+// buildCodespaceBashStdinArgs returns a short gh invocation that reads setup commands from stdin.
+func buildCodespaceBashStdinArgs(codespaceName string) []string {
+	return append(
+		[]string{"codespace", "ssh", "--codespace", codespaceName, "--", "-T"},
+		wrapBashLoginCommand("bash -s")...,
+	)
+}
+
+// runCodespaceBashScript executes script in the codespace without placing the script in argv.
+func runCodespaceBashScript(ctx context.Context, codespaceName, script string) (string, error) {
+	ghExe, err := gh.Path()
 	if err != nil {
-		return fmt.Errorf("error preparing scripts: %w\nStderr: %s", err, stderr.String())
+		return "", err
 	}
 
-	// Print success messages
-	fmt.Fprintln(os.Stderr, "ADO and Azure auth helpers uploaded to the codespace and made executable")
-	fmt.Fprintln(os.Stderr, "xdg-open installed at /usr/local/bin/xdg-open")
-	if hasBrowserService {
-		fmt.Fprintf(os.Stderr, "\nBrowser opener available! To enable browser forwarding, add to your shell config:\n")
-		fmt.Fprintf(os.Stderr, "  export BROWSER=\"$HOME/browser-opener.sh\"\n\n")
+	cmd := exec.CommandContext(ctx, ghExe, buildCodespaceBashStdinArgs(codespaceName)...)
+	cmd.Stdin = strings.NewReader(script)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return stderr.String(), fmt.Errorf("gh execution failed: %w", err)
 	}
 
-	return nil
+	return stderr.String(), nil
 }
 
 func buildStaleSocketCleanupCommand(hasBrowserService, hasNotificationService bool) string {

--- a/main_test.go
+++ b/main_test.go
@@ -284,6 +284,56 @@ func TestBuildStaleSocketCleanupCommand(t *testing.T) {
 	})
 }
 
+func TestBuildCodespaceBashStdinArgs(t *testing.T) {
+	args := buildCodespaceBashStdinArgs("test-codespace")
+	joinedArgs := strings.Join(args, " ")
+
+	expected := []string{
+		"codespace",
+		"ssh",
+		"--codespace",
+		"test-codespace",
+		"--",
+		"-T",
+		"bash",
+		"-lc",
+		"'bash -s'",
+	}
+
+	if strings.Join(expected, " ") != joinedArgs {
+		t.Fatalf("buildCodespaceBashStdinArgs() = %q, want %q", joinedArgs, strings.Join(expected, " "))
+	}
+
+	if strings.Contains(joinedArgs, "ado-auth-helper") || strings.Contains(joinedArgs, "base64") {
+		t.Fatalf("codespace setup payload should be sent over stdin, not argv: %q", joinedArgs)
+	}
+}
+
+func TestBuildCodespacePreparationScript(t *testing.T) {
+	script := buildCodespacePreparationScript(true, true)
+
+	expectedSnippets := []string{
+		"set -e\n",
+		"> ~/ado-auth-helper && cp ~/ado-auth-helper ~/azure-auth-helper",
+		"> ~/port-monitor.sh",
+		"> ~/browser-opener.sh",
+		"> ~/notification-sender.sh",
+		"> ~/xdg-open.sh",
+		"chmod +x ~/ado-auth-helper ~/azure-auth-helper ~/port-monitor.sh ~/xdg-open.sh ~/browser-opener.sh ~/notification-sender.sh",
+		"sudo ln -sf ~/ado-auth-helper /usr/local/bin/ado-auth-helper",
+		"sudo ln -sf ~/azure-auth-helper /usr/local/bin/azure-auth-helper",
+		"sudo ln -sf ~/xdg-open.sh /usr/local/bin/xdg-open",
+		"/tmp/gh-ado-browser-*.sock",
+		"/tmp/gh-ado-notification-*.sock",
+	}
+
+	for _, snippet := range expectedSnippets {
+		if !strings.Contains(script, snippet) {
+			t.Errorf("Expected setup script to contain %q", snippet)
+		}
+	}
+}
+
 // TestGetLogDirectory verifies log directory path generation
 func TestGetLogDirectory(t *testing.T) {
 	logDir := getLogDirectory()


### PR DESCRIPTION
## Summary
- Send the codespace preparation script over stdin instead of passing the full base64 payload as a `gh.exe` argument.
- Keep setup in one SSH session while avoiding Windows command-line length limits.
- Add coverage for the short argv path and generated setup script.

## Validation
- `go test -v ./...`
- `go vet ./...`
