### PR TITLE
Add X11 tunneling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,13 @@ gh ado-codespaces -- -L 3000:localhost:3000
 
 ### X11 Tunneling
 
-When the host has a non-empty `DISPLAY` environment variable, interactive sessions automatically add trusted X11 forwarding with `-Y`. Install and start an X11 server on the host first (for example, XQuartz on macOS).
+When the host has a non-empty `DISPLAY` environment variable, interactive sessions automatically add trusted X11 forwarding with `-Y`. Trusted forwarding lets codespace applications access the local X server, so use it only with codespaces you trust. Install and start an X11 server on the host first (for example, XQuartz on macOS).
+
+To disable X11 forwarding for a session, pass `-x` after the separator:
+
+```fish
+gh ado-codespaces -- -x
+```
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ You can also pass additional SSH flags after `--`, for example:
 gh ado-codespaces -- -L 3000:localhost:3000
 ```
 
+### X11 Tunneling
+
+When the host has a non-empty `DISPLAY` environment variable, interactive sessions automatically add trusted X11 forwarding with `-Y`. Install and start an X11 server on the host first (for example, XQuartz on macOS).
+
 ### Configuration
 
 The extension can read optional configuration values that are scoped per GitHub login. By default it looks for a JSON file at:

--- a/args.go
+++ b/args.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -144,10 +145,20 @@ func (args *CommandLineArgs) BuildSSHArgs(socketPath string, port int, browserSe
 		sshArgs = append(sshArgs, reverseArgs...)
 	}
 
+	if supportsX11Tunneling() {
+		sshArgs = append(sshArgs, "-Y")
+	}
+
 	sshArgs = append(sshArgs, "-t")
 
 	// Append remaining user-provided arguments (ssh flags or command)
 	sshArgs = append(sshArgs, args.RemainingArgs...)
 
 	return sshArgs
+}
+
+// supportsX11Tunneling reports whether the host has an X11 display available for forwarding.
+func supportsX11Tunneling() bool {
+	display, present := os.LookupEnv("DISPLAY")
+	return present && strings.TrimSpace(display) != ""
 }

--- a/args_test.go
+++ b/args_test.go
@@ -179,6 +179,52 @@ func TestCommandLineArgs_BuildSSHArgs(t *testing.T) {
 	}
 }
 
+func TestSupportsX11Tunneling(t *testing.T) {
+	tests := []struct {
+		name    string
+		display string
+		want    bool
+	}{
+		{name: "display is empty", display: "", want: false},
+		{name: "display is whitespace", display: "  ", want: false},
+		{name: "local display", display: ":0", want: true},
+		{name: "remote display", display: "localhost:10.0", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DISPLAY", tt.display)
+
+			if got := supportsX11Tunneling(); got != tt.want {
+				t.Errorf("supportsX11Tunneling() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandLineArgs_BuildSSHArgsWithX11Tunneling(t *testing.T) {
+	t.Setenv("DISPLAY", ":0")
+
+	args := CommandLineArgs{}
+	sshArgs := args.BuildSSHArgs("/tmp/socket", 8080, nil, nil)
+	want := []string{"-Y", "-t"}
+
+	for i := 0; i <= len(sshArgs)-len(want); i++ {
+		matches := true
+		for j := range want {
+			if sshArgs[i+j] != want[j] {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return
+		}
+	}
+
+	t.Errorf("BuildSSHArgs() = %v, want X11 options %v", sshArgs, want)
+}
+
 // Test helper function to capture os.Args manipulation
 func withArgs(args []string, fn func()) {
 	oldArgs := os.Args


### PR DESCRIPTION
Enable GUI applications in interactive Codespace sessions when the host has an X11 display available.

When `DISPLAY` is non-empty, the extension adds trusted X11 forwarding with `-Y` to the interactive SSH command. Setup connections remain unchanged, and tests cover display detection and argument generation.