### PR TITLE
Add Herdr remote client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To use Herdr as the interactive remote client instead of opening an SSH shell:
 gh ado-codespaces --herdr
 ```
 
-The extension performs the same setup, writes GitHub CLI-generated Codespaces entries to a managed OpenSSH include, and launches `herdr --remote <codespace-name>`. Keep the extension process running while using Herdr because the authentication, browser, notification, and port-forwarding services are local to that process.
+The extension performs the same setup, writes GitHub CLI-generated Codespaces entries to a managed OpenSSH include, and launches Herdr with an internal session-specific SSH host alias for the selected Codespace. Keep the extension process running while using Herdr because the authentication, browser, notification, and port-forwarding services are local to that process.
 
 ### Command Line Options
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ When working with GitHub Codespaces and Azure DevOps services, authentication ca
 - [GitHub CLI](https://cli.github.com/) (`gh`) installed and authenticated
 - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) (`az`) installed and logged in to the appropriate tenant
 - A GitHub Codespace with [Artifacts Helper](https://github.com/microsoft/codespace-features/tree/main/src/artifacts-helper) configured
+- [Herdr](https://herdr.dev/) installed locally when using `--herdr`
 
 ## Installation
 
@@ -46,6 +47,14 @@ The extension will:
 4. Start an interactive SSH session
 5. Automatically forward detected application ports from your codespace
 
+To use Herdr as the interactive remote client instead of opening an SSH shell:
+
+```fish
+gh ado-codespaces --herdr
+```
+
+The extension performs the same setup, writes GitHub CLI-generated Codespaces entries to a managed OpenSSH include, and launches `herdr --remote <codespace-name>`. Keep the extension process running while using Herdr because the authentication, browser, notification, and port-forwarding services are local to that process.
+
 ### Command Line Options
 
 ```
@@ -58,6 +67,7 @@ Flags:
   --debug, -d                Log debug data to a file
   --debug-file string        Path of the file to log to
   --azure-subscription-id string  Azure subscription ID to use for authentication (persisted per GitHub account)
+  --herdr                    Connect with Herdr instead of an interactive SSH session
   --profile string           Name of the SSH profile to use
   --repo, -R string          Filter codespace selection by repository name (user/repo)
   --repo-owner string        Filter codespace selection by repository owner (username or org)
@@ -68,6 +78,20 @@ You can also pass additional SSH flags after `--`, for example:
 
 ```fish
 gh ado-codespaces -- -L 3000:localhost:3000
+```
+
+Arguments after `--` are not supported with `--herdr` because Herdr owns the SSH invocation.
+The `--profile` and `--server-port` options are also unavailable in Herdr mode because GitHub CLI cannot combine them with generated OpenSSH configuration.
+
+### Herdr remote sessions
+
+Herdr mode uses `gh codespace ssh --config` to maintain reusable host entries under `~/.ssh/gh-ado-codespaces/`. The extension adds idempotent `Include` lines to `~/.ssh/config`; it does not replace existing SSH configuration. Dynamic forwarding settings are stored in a session file and removed when the extension exits.
+
+You can combine Herdr mode with the existing selection filters:
+
+```fish
+gh ado-codespaces --herdr --repo owner/repository
+gh ado-codespaces --herdr --codespace codespace-name
 ```
 
 ### X11 Tunneling
@@ -168,6 +192,7 @@ See [docs/testing.md](docs/testing.md) for the full test suite overview and addi
 
 - Authentication is tied to your local Azure CLI session
 - Initial setup with Artifacts Helper is required in the codespace
+- Herdr mode requires the system OpenSSH client to honor `~/.ssh/config`
 
 ## Acknowledgments
 

--- a/args.go
+++ b/args.go
@@ -16,6 +16,7 @@ type CommandLineArgs struct {
 	Debug               bool
 	DebugFile           string
 	AzureSubscriptionId string
+	Herdr               bool
 	Logs                bool
 	Profile             string
 	Repo                string
@@ -32,6 +33,7 @@ func ParseArgs() CommandLineArgs {
 	debugFlag := flag.Bool("debug", false, "Log debug data to a file")
 	dFlag := flag.Bool("d", false, "Log debug data to a file (shorthand for --debug)")
 	debugFile := flag.String("debug-file", "", "Path of the file log to")
+	herdrFlag := flag.Bool("herdr", false, "Connect with Herdr instead of an interactive SSH session")
 	logsFlag := flag.Bool("logs", false, "List recent log files and exit")
 	azureSub := flag.String("azure-subscription-id", "", "Azure subscription ID to use for authentication (persisted per GitHub account)")
 	// Allow an alternate flag name without -id suffix for convenience
@@ -69,6 +71,7 @@ func ParseArgs() CommandLineArgs {
 		Debug:               actualDebug,
 		DebugFile:           *debugFile,
 		AzureSubscriptionId: strings.TrimSpace(actualAzureSub),
+		Herdr:               *herdrFlag,
 		Logs:                *logsFlag,
 		Profile:             *profile,
 		Repo:                actualRepo,
@@ -76,6 +79,31 @@ func ParseArgs() CommandLineArgs {
 		ServerPort:          *serverPort,
 		RemainingArgs:       flag.Args(),
 	}
+}
+
+// Validate checks command-line option combinations that cannot be supported.
+func (args *CommandLineArgs) Validate() error {
+	if !args.Herdr {
+		return nil
+	}
+
+	if args.Config {
+		return fmt.Errorf("--config cannot be combined with --herdr")
+	}
+
+	if args.Profile != "" {
+		return fmt.Errorf("--profile cannot be combined with --herdr because GitHub CLI does not support it with generated SSH config")
+	}
+
+	if args.ServerPort != 0 {
+		return fmt.Errorf("--server-port cannot be combined with --herdr because GitHub CLI does not support it with generated SSH config")
+	}
+
+	if len(args.RemainingArgs) > 0 {
+		return fmt.Errorf("SSH arguments after -- cannot be used with --herdr")
+	}
+
+	return nil
 }
 
 // BuildGHFlags builds the arguments for the 'gh codespace ssh' command
@@ -121,28 +149,8 @@ func (args *CommandLineArgs) BuildGHFlags() []string {
 func (args *CommandLineArgs) BuildSSHArgs(socketPath string, port int, browserService *BrowserService, notificationService *NotificationService) []string {
 	sshArgs := []string{"--"} // Start with the separator
 
-	// Add the auth socket forward
-	forwardSpec := fmt.Sprintf("%s:%s:%d", socketPath, localServiceHost, port)
-	sshArgs = append(sshArgs, "-R", forwardSpec)
-
-	// Add browser socket forward if browser service is available
-	if browserService != nil {
-		browserForwardSpec := fmt.Sprintf("%s:%s:%d", browserService.SocketPath, localServiceHost, browserService.Port)
-		sshArgs = append(sshArgs, "-R", browserForwardSpec)
-	}
-
-	// Add notification socket forward if notification service is available
-	if notificationService != nil {
-		notificationForwardSpec := fmt.Sprintf("%s:%s:%d", notificationService.SocketPath, localServiceHost, notificationService.Port)
-		sshArgs = append(sshArgs, "-R", notificationForwardSpec)
-	}
-
-	// Detect and add reverse port forwards for local AI services
-	boundForwards := GetBoundReverseForwards()
-	if len(boundForwards) > 0 {
-		LogReverseForwards(boundForwards)
-		reverseArgs := BuildReverseForwardArgs(boundForwards)
-		sshArgs = append(sshArgs, reverseArgs...)
+	for _, forward := range buildRemoteForwards(socketPath, port, browserService, notificationService) {
+		sshArgs = append(sshArgs, "-R", forward.argument())
 	}
 
 	if supportsX11Tunneling() {
@@ -155,6 +163,49 @@ func (args *CommandLineArgs) BuildSSHArgs(socketPath string, port int, browserSe
 	sshArgs = append(sshArgs, args.RemainingArgs...)
 
 	return sshArgs
+}
+
+type remoteForward struct {
+	remote string
+	local  string
+}
+
+func (forward remoteForward) argument() string {
+	return forward.remote + ":" + forward.local
+}
+
+func buildRemoteForwards(socketPath string, port int, browserService *BrowserService, notificationService *NotificationService) []remoteForward {
+	forwards := []remoteForward{{
+		remote: socketPath,
+		local:  fmt.Sprintf("%s:%d", localServiceHost, port),
+	}}
+
+	if browserService != nil {
+		forwards = append(forwards, remoteForward{
+			remote: browserService.SocketPath,
+			local:  fmt.Sprintf("%s:%d", localServiceHost, browserService.Port),
+		})
+	}
+
+	if notificationService != nil {
+		forwards = append(forwards, remoteForward{
+			remote: notificationService.SocketPath,
+			local:  fmt.Sprintf("%s:%d", localServiceHost, notificationService.Port),
+		})
+	}
+
+	boundForwards := GetBoundReverseForwards()
+	if len(boundForwards) > 0 {
+		LogReverseForwards(boundForwards)
+		for _, forward := range boundForwards {
+			forwards = append(forwards, remoteForward{
+				remote: fmt.Sprint(forward.Port),
+				local:  fmt.Sprintf("localhost:%d", forward.Port),
+			})
+		}
+	}
+
+	return forwards
 }
 
 // supportsX11Tunneling reports whether the host has an X11 display available for forwarding.

--- a/args_test.go
+++ b/args_test.go
@@ -95,6 +95,30 @@ func TestCommandLineArgs_BuildGHFlags(t *testing.T) {
 	}
 }
 
+func TestCommandLineArgs_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    CommandLineArgs
+		wantErr bool
+	}{
+		{name: "standard SSH mode", args: CommandLineArgs{}},
+		{name: "Herdr mode", args: CommandLineArgs{Herdr: true}},
+		{name: "Herdr with config", args: CommandLineArgs{Herdr: true, Config: true}, wantErr: true},
+		{name: "Herdr with profile", args: CommandLineArgs{Herdr: true, Profile: "work"}, wantErr: true},
+		{name: "Herdr with server port", args: CommandLineArgs{Herdr: true, ServerPort: 2222}, wantErr: true},
+		{name: "Herdr with SSH arguments", args: CommandLineArgs{Herdr: true, RemainingArgs: []string{"-L", "3000:localhost:3000"}}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.args.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestCommandLineArgs_BuildSSHArgs(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -244,6 +268,7 @@ func TestParseArgs_StructFields(t *testing.T) {
 		Debug:               true,
 		DebugFile:           "test.log",
 		AzureSubscriptionId: "test-sub",
+		Herdr:               true,
 		Logs:                true,
 		Profile:             "test-profile",
 		Repo:                "test/repo",
@@ -267,6 +292,9 @@ func TestParseArgs_StructFields(t *testing.T) {
 	}
 	if args.AzureSubscriptionId != "test-sub" {
 		t.Errorf("Expected AzureSubscriptionId to be 'test-sub', got %s", args.AzureSubscriptionId)
+	}
+	if !args.Herdr {
+		t.Error("Expected Herdr to be true")
 	}
 	if !args.Logs {
 		t.Error("Expected Logs to be true")

--- a/herdr.go
+++ b/herdr.go
@@ -34,7 +34,7 @@ func newHerdrSSHConfig(homeDir, codespaceName, currentSessionID string) herdrSSH
 
 	return herdrSSHConfig{
 		rootDir:     rootDir,
-		hostFile:    filepath.Join(rootDir, herdrHostsDirectory, sanitizeForFilename(codespaceName)+".conf"),
+		hostFile:    filepath.Join(rootDir, herdrHostsDirectory, hostConfigFileName(codespaceName)),
 		sessionFile: filepath.Join(rootDir, herdrSessionsDirectory, sessionConfigFileName(currentSessionID)),
 		mainConfig:  filepath.Join(homeDir, ".ssh", "config"),
 	}
@@ -147,6 +147,12 @@ func sessionConfigFileName(currentSessionID string) string {
 	sessionHash := sha256.Sum256([]byte(currentSessionID))
 
 	return fmt.Sprintf("session-%x.conf", sessionHash[:8])
+}
+
+func hostConfigFileName(codespaceName string) string {
+	nameHash := sha256.Sum256([]byte(codespaceName))
+
+	return fmt.Sprintf("%s-%x.conf", sanitizeForFilename(codespaceName), nameHash[:8])
 }
 
 func validateSSHHostAlias(alias string) error {

--- a/herdr.go
+++ b/herdr.go
@@ -1,0 +1,353 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/cli/go-gh/v2"
+)
+
+const (
+	herdrSSHDirectoryName  = "gh-ado-codespaces"
+	herdrHostsDirectory    = "hosts"
+	herdrSessionsDirectory = "sessions"
+	herdrConfigBlockStart  = "# gh-ado-codespaces managed includes"
+	herdrConfigBlockEnd    = "# end gh-ado-codespaces managed includes"
+)
+
+type herdrSSHConfig struct {
+	rootDir     string
+	hostFile    string
+	sessionFile string
+	mainConfig  string
+}
+
+func newHerdrSSHConfig(homeDir, codespaceName, currentSessionID string) herdrSSHConfig {
+	rootDir := filepath.Join(homeDir, ".ssh", herdrSSHDirectoryName)
+
+	return herdrSSHConfig{
+		rootDir:     rootDir,
+		hostFile:    filepath.Join(rootDir, herdrHostsDirectory, sanitizeForFilename(codespaceName)+".conf"),
+		sessionFile: filepath.Join(rootDir, herdrSessionsDirectory, sessionConfigFileName(currentSessionID)),
+		mainConfig:  filepath.Join(homeDir, ".ssh", "config"),
+	}
+}
+
+func findHerdrExecutable() (string, error) {
+	path, err := exec.LookPath("herdr")
+	if err != nil {
+		return "", fmt.Errorf("herdr is not installed or is not on PATH; install it from https://herdr.dev: %w", err)
+	}
+
+	return path, nil
+}
+
+func buildHerdrArgs(codespaceName string) []string {
+	return []string{"--remote", codespaceName}
+}
+
+func buildCodespaceSSHConfigArgs(args *CommandLineArgs) []string {
+	configArgs := []string{"codespace", "ssh", "--codespace", args.CodespaceName, "--config"}
+
+	if args.Debug {
+		configArgs = append(configArgs, "--debug")
+	}
+	if args.DebugFile != "" {
+		configArgs = append(configArgs, "--debug-file", args.DebugFile)
+	}
+
+	return configArgs
+}
+
+func runHerdr(ctx context.Context, executable, codespaceName string) error {
+	cmd := exec.CommandContext(ctx, executable, buildHerdrArgs(codespaceName)...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("herdr remote session failed: %w", err)
+	}
+
+	return nil
+}
+
+func generateCodespaceSSHConfig(ctx context.Context, args *CommandLineArgs) (string, error) {
+	ghExe, err := gh.Path()
+	if err != nil {
+		return "", fmt.Errorf("failed to locate gh executable: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, ghExe, buildCodespaceSSHConfigArgs(args)...)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to generate SSH config for codespace %q: %w\n%s", args.CodespaceName, err, strings.TrimSpace(stderr.String()))
+	}
+
+	if strings.TrimSpace(stdout.String()) == "" {
+		return "", fmt.Errorf("gh returned an empty SSH config for codespace %q", args.CodespaceName)
+	}
+
+	return stdout.String(), nil
+}
+
+func setupHerdrSSHConfig(ctx context.Context, codespaceName string, args *CommandLineArgs, serverConfig *ServerConfig, browserService *BrowserService, notificationService *NotificationService) (string, func(), error) {
+	if err := validateSSHHostAlias(codespaceName); err != nil {
+		return "", nil, err
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to determine home directory: %w", err)
+	}
+
+	generatedConfig, err := generateCodespaceSSHConfig(ctx, args)
+	if err != nil {
+		return "", nil, err
+	}
+
+	herdrHostAlias := buildHerdrSSHHostAlias(codespaceName, sessionID)
+	paths := newHerdrSSHConfig(homeDir, codespaceName, sessionID)
+	sessionConfig, err := buildHerdrSessionConfig(generatedConfig, herdrHostAlias, serverConfig, browserService, notificationService)
+	if err != nil {
+		return "", nil, err
+	}
+	if err := paths.write(generatedConfig, sessionConfig); err != nil {
+		return "", nil, err
+	}
+
+	cleanup := func() {
+		if err := os.Remove(paths.sessionFile); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "Warning: failed to remove Herdr SSH session config: %v\n", err)
+		}
+	}
+
+	return herdrHostAlias, cleanup, nil
+}
+
+func buildHerdrSSHHostAlias(codespaceName, currentSessionID string) string {
+	sessionHash := sha256.Sum256([]byte(currentSessionID))
+
+	return sanitizeForFilename(codespaceName) + fmt.Sprintf("--gh-ado-%x", sessionHash[:8])
+}
+
+func sessionConfigFileName(currentSessionID string) string {
+	sessionHash := sha256.Sum256([]byte(currentSessionID))
+
+	return fmt.Sprintf("session-%x.conf", sessionHash[:8])
+}
+
+func validateSSHHostAlias(alias string) error {
+	if alias == "" {
+		return fmt.Errorf("codespace name cannot be empty")
+	}
+
+	for _, character := range alias {
+		isLetter := character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z'
+		isDigit := character >= '0' && character <= '9'
+		if !isLetter && !isDigit && character != '-' && character != '_' && character != '.' {
+			return fmt.Errorf("codespace name %q cannot be used as an SSH host alias", alias)
+		}
+	}
+
+	return nil
+}
+
+func buildHerdrSessionConfig(generatedConfig, herdrHostAlias string, serverConfig *ServerConfig, browserService *BrowserService, notificationService *NotificationService) (string, error) {
+	aliasedConfig, err := replaceGeneratedSSHHostAlias(generatedConfig, herdrHostAlias)
+	if err != nil {
+		return "", err
+	}
+
+	var config strings.Builder
+	config.WriteString(aliasedConfig)
+	if !strings.HasSuffix(aliasedConfig, "\n") {
+		config.WriteString("\n")
+	}
+	fmt.Fprintf(&config, "\nHost %s\n", herdrHostAlias)
+	for _, forward := range buildRemoteForwards(serverConfig.SocketPath, serverConfig.Port, browserService, notificationService) {
+		fmt.Fprintf(&config, "  RemoteForward %s %s\n", forward.remote, forward.local)
+	}
+
+	if supportsX11Tunneling() {
+		config.WriteString("  ForwardX11 yes\n")
+		config.WriteString("  ForwardX11Trusted yes\n")
+	}
+
+	return config.String(), nil
+}
+
+func replaceGeneratedSSHHostAlias(config, newAlias string) (string, error) {
+	lines := strings.Split(config, "\n")
+	oldAlias := ""
+
+	for index, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || !strings.EqualFold(fields[0], "Host") {
+			continue
+		}
+
+		if oldAlias == "" {
+			oldAlias = fields[1]
+		}
+		if fields[1] != oldAlias {
+			return "", fmt.Errorf("GitHub CLI SSH config contained multiple Host aliases")
+		}
+
+		indentLength := len(line) - len(strings.TrimLeft(line, " \t"))
+		lines[index] = line[:indentLength] + "Host " + newAlias
+	}
+
+	if oldAlias == "" {
+		return "", fmt.Errorf("GitHub CLI SSH config did not contain a Host entry")
+	}
+
+	return strings.Join(lines, "\n"), nil
+}
+
+func (config herdrSSHConfig) write(hostConfig, sessionConfig string) error {
+	if err := os.MkdirAll(filepath.Dir(config.hostFile), 0700); err != nil {
+		return fmt.Errorf("failed to create Herdr SSH host directory: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(config.sessionFile), 0700); err != nil {
+		return fmt.Errorf("failed to create Herdr SSH session directory: %w", err)
+	}
+	if err := os.Chmod(config.rootDir, 0700); err != nil {
+		return fmt.Errorf("failed to secure Herdr SSH config directory: %w", err)
+	}
+	if err := os.Chmod(filepath.Dir(config.hostFile), 0700); err != nil {
+		return fmt.Errorf("failed to secure Herdr SSH host directory: %w", err)
+	}
+	if err := os.Chmod(filepath.Dir(config.sessionFile), 0700); err != nil {
+		return fmt.Errorf("failed to secure Herdr SSH session directory: %w", err)
+	}
+
+	if err := writeFileAtomically(config.hostFile, []byte(hostConfig), 0600); err != nil {
+		return fmt.Errorf("failed to write Codespaces SSH config: %w", err)
+	}
+	if err := writeFileAtomically(config.sessionFile, []byte(sessionConfig), 0600); err != nil {
+		return fmt.Errorf("failed to write Herdr SSH session config: %w", err)
+	}
+	if err := ensureHerdrSSHIncludes(config.mainConfig, config.rootDir); err != nil {
+		_ = os.Remove(config.sessionFile)
+
+		return err
+	}
+
+	return nil
+}
+
+func ensureHerdrSSHIncludes(mainConfig, rootDir string) error {
+	if err := os.MkdirAll(filepath.Dir(mainConfig), 0700); err != nil {
+		return fmt.Errorf("failed to create SSH directory: %w", err)
+	}
+
+	writePath, err := resolveSSHConfigWritePath(mainConfig)
+	if err != nil {
+		return err
+	}
+
+	existing, err := os.ReadFile(writePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read SSH config: %w", err)
+	}
+
+	sessionInclude := fmt.Sprintf("Include %s", strconv.Quote(filepath.Join(rootDir, herdrSessionsDirectory, "*.conf")))
+	hostInclude := fmt.Sprintf("Include %s", strconv.Quote(filepath.Join(rootDir, herdrHostsDirectory, "*.conf")))
+	content := string(existing)
+	managedBlock := strings.Join([]string{
+		herdrConfigBlockStart,
+		"Match all",
+		sessionInclude,
+		"Match all",
+		hostInclude,
+		"Match all",
+		herdrConfigBlockEnd,
+	}, "\n")
+
+	content = removeManagedSSHConfigBlock(content)
+	content = strings.TrimLeft(content, "\n")
+	if content == "" {
+		content = managedBlock + "\n"
+	} else {
+		content = managedBlock + "\n\n" + content
+	}
+
+	if string(existing) == content {
+		return nil
+	}
+
+	if err := writeFileAtomically(writePath, []byte(content), 0600); err != nil {
+		return fmt.Errorf("failed to update SSH config includes: %w", err)
+	}
+
+	return nil
+}
+
+func resolveSSHConfigWritePath(mainConfig string) (string, error) {
+	info, err := os.Lstat(mainConfig)
+	if os.IsNotExist(err) {
+		return mainConfig, nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect SSH config: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return mainConfig, nil
+	}
+
+	resolved, err := filepath.EvalSymlinks(mainConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve SSH config symlink: %w", err)
+	}
+
+	return resolved, nil
+}
+
+func removeManagedSSHConfigBlock(content string) string {
+	blockStart := strings.Index(content, herdrConfigBlockStart)
+	blockEnd := strings.Index(content, herdrConfigBlockEnd)
+	if blockStart >= 0 && blockEnd >= blockStart {
+		blockEnd += len(herdrConfigBlockEnd)
+		return content[:blockStart] + content[blockEnd:]
+	}
+
+	return content
+}
+
+func writeFileAtomically(path string, content []byte, mode os.FileMode) error {
+	tempFile, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	defer os.Remove(tempPath)
+
+	if err := tempFile.Chmod(mode); err != nil {
+		_ = tempFile.Close()
+
+		return err
+	}
+	if _, err := tempFile.Write(content); err != nil {
+		_ = tempFile.Close()
+
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tempPath, path)
+}

--- a/herdr_test.go
+++ b/herdr_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildHerdrArgs(t *testing.T) {
+	got := buildHerdrArgs("test-codespace")
+	want := []string{"--remote", "test-codespace"}
+
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("buildHerdrArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestBuildCodespaceSSHConfigArgs(t *testing.T) {
+	args := &CommandLineArgs{
+		CodespaceName: "test-codespace",
+		Debug:         true,
+		DebugFile:     "/tmp/gh-debug.log",
+		Repo:          "owner/repo",
+		RepoOwner:     "owner",
+	}
+
+	got := buildCodespaceSSHConfigArgs(args)
+	want := []string{
+		"codespace", "ssh",
+		"--codespace", "test-codespace",
+		"--config",
+		"--debug",
+		"--debug-file", "/tmp/gh-debug.log",
+	}
+
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("buildCodespaceSSHConfigArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestFindHerdrExecutableMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := findHerdrExecutable()
+	if err == nil {
+		t.Fatal("findHerdrExecutable() expected an error")
+	}
+	if !strings.Contains(err.Error(), "https://herdr.dev") {
+		t.Fatalf("findHerdrExecutable() error = %q, want installation URL", err)
+	}
+}
+
+func TestValidateSSHHostAlias(t *testing.T) {
+	tests := []struct {
+		alias   string
+		wantErr bool
+	}{
+		{alias: "friendly-space-123"},
+		{alias: "codespace.example_test"},
+		{alias: "", wantErr: true},
+		{alias: "bad host", wantErr: true},
+		{alias: "bad\nHost injected", wantErr: true},
+		{alias: "*", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.alias, func(t *testing.T) {
+			err := validateSSHHostAlias(tt.alias)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateSSHHostAlias(%q) error = %v, wantErr %t", tt.alias, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildHerdrSSHHostAliasIsSessionSpecific(t *testing.T) {
+	longCodespaceName := strings.Repeat("a", 60)
+	first := buildHerdrSSHHostAlias(longCodespaceName, longCodespaceName+"_session-one")
+	second := buildHerdrSSHHostAlias(longCodespaceName, longCodespaceName+"_session-two")
+
+	if first == second {
+		t.Fatalf("session aliases must be unique, got %q", first)
+	}
+	if !strings.HasPrefix(first, strings.Repeat("a", 50)+"--gh-ado-") {
+		t.Fatalf("unexpected session alias %q", first)
+	}
+}
+
+func TestBuildHerdrSessionConfig(t *testing.T) {
+	originalPorts := WellKnownPorts
+	WellKnownPorts = []ReversePortForward{{
+		Port:          1234,
+		Description:   "Test service",
+		Enabled:       true,
+		AlwaysForward: true,
+	}}
+	defer func() { WellKnownPorts = originalPorts }()
+
+	t.Setenv("DISPLAY", ":0")
+	serverConfig := &ServerConfig{SocketPath: "/tmp/auth.sock", Port: 8080}
+	browserService := &BrowserService{SocketPath: "/tmp/browser.sock", Port: 8081}
+	notificationService := &NotificationService{SocketPath: "/tmp/notification.sock", Port: 8082}
+
+	got, err := buildHerdrSessionConfig(
+		"Host cs.test-codespace.main\n  HostName example.com\n  User codespace\n",
+		"test-codespace--gh-ado-session",
+		serverConfig,
+		browserService,
+		notificationService,
+	)
+	if err != nil {
+		t.Fatalf("buildHerdrSessionConfig() error = %v", err)
+	}
+	expected := []string{
+		"Host test-codespace--gh-ado-session",
+		"HostName example.com",
+		"User codespace",
+		"RemoteForward /tmp/auth.sock 127.0.0.1:8080",
+		"RemoteForward /tmp/browser.sock 127.0.0.1:8081",
+		"RemoteForward /tmp/notification.sock 127.0.0.1:8082",
+		"RemoteForward 1234 localhost:1234",
+		"ForwardX11 yes",
+		"ForwardX11Trusted yes",
+	}
+
+	for _, snippet := range expected {
+		if !strings.Contains(got, snippet) {
+			t.Errorf("buildHerdrSessionConfig() missing %q:\n%s", snippet, got)
+		}
+	}
+}
+
+func TestReplaceSSHHostAliasMissing(t *testing.T) {
+	_, err := replaceGeneratedSSHHostAlias("User codespace\n", "session-alias")
+	if err == nil {
+		t.Fatal("replaceGeneratedSSHHostAlias() expected an error")
+	}
+}
+
+func TestHerdrSSHConfigWrite(t *testing.T) {
+	homeDir := t.TempDir()
+	paths := newHerdrSSHConfig(homeDir, "test-codespace", "test-session")
+
+	existingConfig := "Host example\n  HostName example.com"
+	if err := os.MkdirAll(filepath.Dir(paths.mainConfig), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.mainConfig, []byte(existingConfig), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := paths.write("Host test-codespace\n  HostName example\n", "Host test-codespace\n  RemoteForward /tmp/auth.sock 127.0.0.1:8080\n"); err != nil {
+		t.Fatalf("write() error = %v", err)
+	}
+	if err := paths.write("Host test-codespace\n  HostName updated\n", "Host test-codespace\n  RemoteForward /tmp/auth.sock 127.0.0.1:8080\n"); err != nil {
+		t.Fatalf("second write() error = %v", err)
+	}
+
+	mainConfig, err := os.ReadFile(paths.mainConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(mainConfig)
+	if !strings.Contains(content, existingConfig) {
+		t.Fatalf("main SSH config was not preserved:\n%s", content)
+	}
+	if !strings.HasPrefix(content, herdrConfigBlockStart) {
+		t.Fatalf("managed includes must precede user SSH settings:\n%s", content)
+	}
+	if strings.Count(content, herdrSessionsDirectory+"/*.conf") != 1 {
+		t.Fatalf("session include was not idempotent:\n%s", content)
+	}
+	if strings.Count(content, herdrHostsDirectory+"/*.conf") != 1 {
+		t.Fatalf("host include was not idempotent:\n%s", content)
+	}
+	if strings.Count(content, "Match all") != 3 {
+		t.Fatalf("managed includes must reset prior Host or Match context:\n%s", content)
+	}
+	if strings.Index(content, herdrSessionsDirectory+"/*.conf") > strings.Index(content, herdrHostsDirectory+"/*.conf") {
+		t.Fatalf("session include must precede host include:\n%s", content)
+	}
+
+	hostConfig, err := os.ReadFile(paths.hostFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(hostConfig), "HostName updated") {
+		t.Fatalf("host config was not updated:\n%s", hostConfig)
+	}
+
+	for _, path := range []string{paths.mainConfig, paths.hostFile, paths.sessionFile} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0600 {
+			t.Errorf("%s mode = %o, want 600", path, info.Mode().Perm())
+		}
+	}
+}
+
+func TestHerdrSSHConfigWritePreservesSymlink(t *testing.T) {
+	homeDir := t.TempDir()
+	paths := newHerdrSSHConfig(homeDir, "test-codespace", "test-session")
+	targetDir := t.TempDir()
+	targetConfig := filepath.Join(targetDir, "ssh-config")
+
+	if err := os.MkdirAll(filepath.Dir(paths.mainConfig), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(targetConfig, []byte("Host example\n  HostName example.com\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(targetConfig, paths.mainConfig); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := paths.write("Host test-codespace\n  HostName example\n", "Host session-alias\n  HostName example\n"); err != nil {
+		t.Fatalf("write() error = %v", err)
+	}
+
+	info, err := os.Lstat(paths.mainConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("main SSH config symlink was replaced")
+	}
+
+	targetContent, err := os.ReadFile(targetConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(targetContent), herdrConfigBlockStart) {
+		t.Fatalf("symlink target was not updated:\n%s", targetContent)
+	}
+}
+
+func TestRemoteForwardArgument(t *testing.T) {
+	forward := remoteForward{remote: "/tmp/auth.sock", local: "127.0.0.1:8080"}
+	if got := forward.argument(); got != "/tmp/auth.sock:127.0.0.1:8080" {
+		t.Fatalf("argument() = %q", got)
+	}
+}

--- a/herdr_test.go
+++ b/herdr_test.go
@@ -87,6 +87,22 @@ func TestBuildHerdrSSHHostAliasIsSessionSpecific(t *testing.T) {
 	}
 }
 
+func TestHostConfigFileNameAvoidsTruncationCollisions(t *testing.T) {
+	commonPrefix := strings.Repeat("a", 50)
+	first := hostConfigFileName(commonPrefix + "-first-codespace")
+	second := hostConfigFileName(commonPrefix + "-second-codespace")
+
+	if first == second {
+		t.Fatalf("host config filenames must be unique, got %q", first)
+	}
+	if !strings.HasPrefix(first, commonPrefix+"-") {
+		t.Fatalf("unexpected host config filename %q", first)
+	}
+	if !strings.HasSuffix(first, ".conf") {
+		t.Fatalf("host config filename must use .conf extension, got %q", first)
+	}
+}
+
 func TestBuildHerdrSessionConfig(t *testing.T) {
 	originalPorts := WellKnownPorts
 	WellKnownPorts = []ReversePortForward{{

--- a/main.go
+++ b/main.go
@@ -45,6 +45,21 @@ func main() {
 		return
 	}
 
+	if err := args.Validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return
+	}
+
+	var herdrExecutable string
+	if args.Herdr {
+		var err error
+		herdrExecutable, err = findHerdrExecutable()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return
+		}
+	}
+
 	cfg, cfgErr := LoadAppConfig()
 	if cfgErr != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to load config: %v\n", cfgErr)
@@ -164,13 +179,6 @@ func main() {
 		defer notificationService.Stop()
 	}
 
-	// Build command line arguments for gh
-	ghFlags := args.BuildGHFlags()
-	sshArgs := args.BuildSSHArgs(serverConfig.SocketPath, serverConfig.Port, browserService, notificationService)
-
-	// Combine all arguments
-	finalArgs := append(ghFlags, sshArgs...)
-
 	// Upload all scripts and configure them in a single SSH call
 	if err := prepareCodespaceScripts(ctx, args.CodespaceName, browserService != nil, notificationService != nil); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to prepare codespace scripts: %v\n", err)
@@ -198,8 +206,25 @@ func main() {
 		monitorController.Wait() // Wait for cleanup
 	}()
 
-	// Execute the command
-	// Pass the cancellable context to gh.ExecInteractive
+	if args.Herdr {
+		herdrHostAlias, cleanupSSHConfig, err := setupHerdrSSHConfig(ctx, args.CodespaceName, &args, serverConfig, browserService, notificationService)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return
+		}
+		defer cleanupSSHConfig()
+
+		if err := runHerdr(ctx, herdrExecutable, herdrHostAlias); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
+
+		return
+	}
+
+	ghFlags := args.BuildGHFlags()
+	sshArgs := args.BuildSSHArgs(serverConfig.SocketPath, serverConfig.Port, browserService, notificationService)
+	finalArgs := append(ghFlags, sshArgs...)
+
 	gh.ExecInteractive(ctx, finalArgs...)
 }
 


### PR DESCRIPTION
## Summary
- add a `--herdr` mode that launches `herdr --remote` after the existing Codespace setup
- manage secure OpenSSH includes with isolated per-session aliases and forwarding configuration
- preserve authentication, browser, notification, reverse-forwarding, X11, and port-monitor behavior
- document Herdr usage and incompatible SSH-only options

## Testing
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`
- verified generated include ordering and `RemoteForward` resolution with `ssh -G`